### PR TITLE
Turning off emails after registrations

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -24,7 +24,6 @@ class RegistrationsController < ApplicationController
     rescue Stripe::CardError, Stripe::InvalidRequestError, Stripe::StripeError, Stripe::AuthenticationError, Stripe::RateLimitError, Stripe::APIConnectionError  => e
     flash[:error] = e.message
     redirect_to event_path(current_event)
-    send_declined_email(current_event, current_user)
     end
   end
 
@@ -32,9 +31,5 @@ class RegistrationsController < ApplicationController
 
   def current_event
     @current_event ||= Event.find(params[:event_id])
-  end
-
-  def send_declined_email(current_event, current_user)
-    NotificationMailer.send_declined_notice(current_event, current_user).deliver_now
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -2,7 +2,6 @@ class Registration < ApplicationRecord
   belongs_to :event
   belongs_to :user
   scope :ordered_by_user_name, -> { joins(:user).order('users.last_name') }
-  after_create :send_registration_email, :send_admin_email
 
   def registration_time
     created_at.strftime('%b %e, %l:%M %p')


### PR DESCRIPTION
Stripe already emails a receipt. Sendgrid is going to 2FA and we are not going to upgrade at this time.